### PR TITLE
fix c99 error in Xcode9

### DIFF
--- a/FastSocket.m
+++ b/FastSocket.m
@@ -48,7 +48,7 @@
 #include <netdb.h>
 #include <netinet/tcp.h>
 #include <unistd.h>
-
+#include <sys/time.h>
 
 int connect_timeout(int sockfd, const struct sockaddr *address, socklen_t address_len, long timeout);
 


### PR DESCRIPTION
In Xcode9, errors occurred in FastSocket.m Line 426:
Implicit declaration of function 'select' is invalid in C99
Declaration of 'select' must be imported from module 'Darwin.POSIX.sys.time' before it is required