### PR TITLE
Misc fixes

### DIFF
--- a/FastSocket.xcodeproj/project.pbxproj
+++ b/FastSocket.xcodeproj/project.pbxproj
@@ -422,7 +422,7 @@
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "${TARGET_NAME:rfc1034identifier}";
 			};
@@ -486,7 +486,7 @@
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				PRODUCT_NAME = "${TARGET_NAME:rfc1034identifier}";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -495,7 +495,6 @@
 		3754B215188C7E0F0052728A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DSTROOT = /tmp/FastSocket.dst;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
@@ -509,7 +508,6 @@
 		3754B216188C7E0F0052728A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DSTROOT = /tmp/FastSocket.dst;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
@@ -558,7 +556,6 @@
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -573,7 +570,6 @@
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
 			};
 			name = Release;
@@ -592,7 +588,6 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "UnitTests-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.danielreese.${PRODUCT_NAME:rfc1034identifier}";
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = xctest;
@@ -610,7 +605,6 @@
 				);
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				INFOPLIST_FILE = "UnitTests-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.danielreese.${PRODUCT_NAME:rfc1034identifier}";
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = xctest;

--- a/FastSocketTest.m
+++ b/FastSocketTest.m
@@ -76,9 +76,9 @@
 }
 
 - (void)testConnectWithDefaultTimeout {
-	// Connect to a non-routable IP address. See http://stackoverflow.com/a/904609/209371
+	// Connect to a non-routable IP address. See https://stackoverflow.com/a/40459270
 	[client close];
-	client = [[FastSocket alloc] initWithHost:@"10.255.255.1" andPort:@"81"];
+	client = [[FastSocket alloc] initWithHost:@"example.com" andPort:@"81"];
 	
 	// Connection should timeout.
 	NSTimeInterval startTime = [NSDate timeIntervalSinceReferenceDate];
@@ -93,9 +93,9 @@
 }
 
 - (void)testConnectWithCustomTimeout {
-	// Connect to a non-routable IP address. See http://stackoverflow.com/a/904609/209371
+	// Connect to a non-routable IP address. See https://stackoverflow.com/a/40459270
 	[client close];
-	client = [[FastSocket alloc] initWithHost:@"10.255.255.1" andPort:@"81"];
+	client = [[FastSocket alloc] initWithHost:@"example.com" andPort:@"81"];
 	
 	// Connection should timeout.
 	NSTimeInterval startTime = [NSDate timeIntervalSinceReferenceDate];


### PR DESCRIPTION
Minor changes

Using `example.com` instead of an unreachable local IP address because it's easier to remember, and that's what it's for. Minor project file cleanup, removing some target-level overrides that were identical to the project setting value.