### PR TITLE
Split release notes into new CHANGELOG file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+FastSocket
+===============
+
+Release Notes
+---------------
+2017 Nov 01 — [v1.6](https://github.com/dreese/FastSocket/releases/tag/v1.6)
+
+	• Fixed a long-standing bug where the internal socket descriptor could become closed but not zeroed out.
+
+2017 Oct 28 — [v1.5](https://github.com/dreese/FastSocket/releases/tag/v1.5)
+
+	• Annotated code to improve auto-generated Swift interface.
+	• Fixed several documentation issues.
+	• Added document for contributions.
+
+2017 Oct 06 — [v1.4](https://github.com/dreese/FastSocket/releases/tag/v1.4)
+
+	• Changed -[FaskSocket timeout] and -[FaskSocket setTimeout:] methods so that the timeout value is a float, in order to handle sub-second values.
+	• Fixed a compatibility issue with Xcode 9.
+	• Added several unit tests.
+
+2015 Jan 27 — [v1.3](https://github.com/dreese/FastSocket/releases/tag/v1.3)
+
+	• Changed -[FaskSocket sendBytes:count:] method to return the actual number of bytes received instead of a BOOL. Now it matches the Readme.
+	• Fixed a compiler warning caused by returning NO instead of nil from one of the init methods.
+	• Added several unit tests.
+
+2014 Feb 03 — [v1.2](https://github.com/dreese/FastSocket/releases/tag/v1.2)
+
+	• Added -[FastSocket connect:] method for specifying a connection timeout, which is separate from the read/write timeout.
+	• Added CocoaPod support with new podspec file.
+
+2013 Oct 03 — [v1.1](https://github.com/dreese/FastSocket/releases/tag/v1.1)
+
+	• Converted to ARC.
+	• Added -[FastSocket isConnected] method.
+	• Added -[FastSocket receiveBytes:count:] method for receiving an exact number of bytes. This differs from -[FastSocket receiveBytes:limit:] in that the new method waits for the given number of bytes is received, or a timeout, before returning.
+	• Added header documentation for use in Xcode 5.
+
+2012 Jun 24 — [v1.0](https://github.com/dreese/FastSocket/releases/tag/v1.0)
+
+	• Initial release.

--- a/FastSocket.xcodeproj/project.pbxproj
+++ b/FastSocket.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		370985EA207C7425009ABEEC /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = SOURCE_ROOT; };
 		373F4A8E189EF6C400A326ED /* FastSocket.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = FastSocket.podspec; sourceTree = SOURCE_ROOT; };
 		3754B1F1188C7E0F0052728A /* libFastSocket-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libFastSocket-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3754B1F4188C7E0F0052728A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -66,7 +67,7 @@
 		3754B22C188C81C30052728A /* libFastSocket-OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libFastSocket-OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3754B230188C81C30052728A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		3754B23D188C81C30052728A /* FastSocket-OSX-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FastSocket-OSX-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		37E6599E1F96CEF800C8E81B /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
+		37E6599E1F96CEF800C8E81B /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -153,6 +154,7 @@
 			isa = PBXGroup;
 			children = (
 				3754B225188C7F3A0052728A /* LICENSE */,
+				370985EA207C7425009ABEEC /* CHANGELOG.md */,
 				37E6599E1F96CEF800C8E81B /* CONTRIBUTING.md */,
 				3754B226188C7F3A0052728A /* README.md */,
 				373F4A8E189EF6C400A326ED /* FastSocket.podspec */,

--- a/README.md
+++ b/README.md
@@ -68,46 +68,6 @@ Close the connection.
 
 Please check out the unit tests for more examples of how to use these classes.
 
-Release Notes
----------------
-2017 Nov 01 — v1.6
-
-	• Fixed a long-standing bug where the internal socket descriptor could become closed but not zeroed out.
-
-2017 Oct 28 — v1.5
-
-	• Annotated code to improve auto-generated Swift interface.
-	• Fixed several documentation issues.
-	• Added document for contributions.
-
-2017 Oct 06 — v1.4
-
-	• Changed -[FaskSocket timeout] and -[FaskSocket setTimeout:] methods so that the timeout value is a float, in order to handle sub-second values.
-	• Fixed a compatibility issue with Xcode 9.
-	• Added several unit tests.
-
-2015 Jan 27 — v1.3
-
-	• Changed -[FaskSocket sendBytes:count:] method to return the actual number of bytes received instead of a BOOL. Now it matches the Readme.
-	• Fixed a compiler warning caused by returning NO instead of nil from one of the init methods.
-	• Added several unit tests.
-
-2014 Feb 03 — v1.2
-
-	• Added -[FastSocket connect:] method for specifying a connection timeout, which is separate from the read/write timeout.
-	• Added CocoaPod support with new podspec file.
-
-2013 Oct 03 — v1.1
-
-	• Converted to ARC.
-	• Added -[FastSocket isConnected] method.
-	• Added -[FastSocket receiveBytes:count:] method for receiving an exact number of bytes. This differs from -[FastSocket receiveBytes:limit:] in that the new method waits for the given number of bytes is received, or a timeout, before returning.
-	• Added header documentation for use in Xcode 5.
-
-2012 Jun 24 — v1.0
-
-	• Initial release.
-
 Creator
 ---------------
 


### PR DESCRIPTION
This makes the CocoaPods page easier to read because the list of releases and changes is not lumped in with the README.